### PR TITLE
Replacing getopt with boost for command-line argument parsing

### DIFF
--- a/cpp/src/RandomNumber/Rand.cc
+++ b/cpp/src/RandomNumber/Rand.cc
@@ -1,62 +1,27 @@
-// ================================================================
-//
-// This software was developed by employees of the National Institute of
-// Standards and Technology (NIST), an agency of the Federal Government.
-// Pursuant to title 17 United States Code Section 105, works of NIST employees
-// are not subject to copyright protection in the United States and are
-// considered to be in the public domain. Permission to freely use, copy,
-// modify, and distribute this software and its documentation without fee is
-// hereby granted, provided that this notice and disclaimer of warranty appears
-// in all copies.
-//
-// THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
-// EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY
-// WARRANTY THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED
-// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM
-// FROM INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO
-// THE SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE. IN NO
-// EVENT SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO,
-// DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF,
-// RESULTING FROM, OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT
-// BASED UPON WARRANTY, CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS
-// SUSTAINED BY PERSONS OR PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS
-// SUSTAINED FROM, OR AROSE OUT OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR
-// SERVICES PROVIDED HEREUNDER.
-//
-// Distributions of NIST software should also include copyright and licensing
-// statements of any third-party software that are legally bundled with the
-// code in compliance with the conditions of those licenses.
-// 
-// ================================================================
-
-// ================================================================
-// 
-// Authors: Derek Juba <derek.juba@nist.gov>
-// Created: Mon Dec 29 11:44:20 2014 EDT
-//
-// ================================================================
-
 #include "Rand.h"
+#include <random>
 
-#include <cstdlib>
-
-// ================================================================
+// mersenne_twister_engine 64-bit
+std::random_device r;
+std::seed_seq ran_seed{r(), r(), r(), r(), r(), r(), r(), r()};
+std::mt19937_64 gen(ran_seed);
 
 Rand::Rand(int streamNum, int numStreams, int seed) {
-  srand(seed);
+	gen.seed(seed);
 }
 
 Rand::~Rand() {
-
 }
 
 double 
 Rand::getRandIn01() {
-  return (rand() / (double)RAND_MAX);
+	std::uniform_real_distribution<> dist(0.0, 1.0);
+	return dist(gen);
 }
 
 double 
 Rand::getRandInRange(double min, double max) {
-  return (rand() / (double)RAND_MAX) * (max - min) + min;
+	std::uniform_real_distribution<> dist(0.0, 1.0);
+	return dist(gen) * (max - min) + min;;
 }
 

--- a/cpp/src/RandomNumber/Rand.h
+++ b/cpp/src/RandomNumber/Rand.h
@@ -1,45 +1,5 @@
-// ================================================================
-//
-// This software was developed by employees of the National Institute of
-// Standards and Technology (NIST), an agency of the Federal Government.
-// Pursuant to title 17 United States Code Section 105, works of NIST employees
-// are not subject to copyright protection in the United States and are
-// considered to be in the public domain. Permission to freely use, copy,
-// modify, and distribute this software and its documentation without fee is
-// hereby granted, provided that this notice and disclaimer of warranty appears
-// in all copies.
-//
-// THE SOFTWARE IS PROVIDED 'AS IS' WITHOUT ANY WARRANTY OF ANY KIND, EITHER
-// EXPRESSED, IMPLIED, OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY
-// WARRANTY THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS, ANY IMPLIED
-// WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND FREEDOM
-// FROM INFRINGEMENT, AND ANY WARRANTY THAT THE DOCUMENTATION WILL CONFORM TO
-// THE SOFTWARE, OR ANY WARRANTY THAT THE SOFTWARE WILL BE ERROR FREE. IN NO
-// EVENT SHALL NIST BE LIABLE FOR ANY DAMAGES, INCLUDING, BUT NOT LIMITED TO,
-// DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF,
-// RESULTING FROM, OR IN ANY WAY CONNECTED WITH THIS SOFTWARE, WHETHER OR NOT
-// BASED UPON WARRANTY, CONTRACT, TORT, OR OTHERWISE, WHETHER OR NOT INJURY WAS
-// SUSTAINED BY PERSONS OR PROPERTY OR OTHERWISE, AND WHETHER OR NOT LOSS WAS
-// SUSTAINED FROM, OR AROSE OUT OF THE RESULTS OF, OR USE OF, THE SOFTWARE OR
-// SERVICES PROVIDED HEREUNDER.
-//
-// Distributions of NIST software should also include copyright and licensing
-// statements of any third-party software that are legally bundled with the
-// code in compliance with the conditions of those licenses.
-// 
-// ================================================================
-
-// ================================================================
-// 
-// Authors: Derek Juba <derek.juba@nist.gov>
-// Created: Mon Dec 29 11:44:20 2014 EDT
-//
-// ================================================================
-
 #ifndef RAND_H_
 #define RAND_H_
-
-// ================================================================
 
 class Rand
 {
@@ -50,7 +10,6 @@ public:
   double getRandIn01();
   double getRandInRange(double min, double max);
 };
-// ================================================================
 
-#endif  // #ifndef RAND_H_
+#endif
 


### PR DESCRIPTION
Uses boost program_options to parse the command-line arguments and config files. However the config files must be in INI format. Essentially now change, however, flag arguments (print-count) must be of the form "print-count = true" instead of only "print-count". So small change.