### PR TITLE
Virial coefficient correctness fixes and tweaks to convergence of overlap parameter

### DIFF
--- a/cpp/libzeno/include/Virials/IntegratorMSMC.h
+++ b/cpp/libzeno/include/Virials/IntegratorMSMC.h
@@ -52,6 +52,7 @@ class IntegratorMSMC {
   void addMove(MCMove<T, RandomNumberGenerator> * mcMove, double moveProb);
   void setMeter(MeterOverlap<T> * meter);
   void setCurrentValue(double currentValue);
+  void setEquilibrationFinished();
 private:
   int threadNum;
   Timer const * totalTimer;
@@ -193,6 +194,20 @@ void
 IntegratorMSMC<T, RandomNumberGenerator>::
 setCurrentValue(double currentValue) {
     this->currentValue = currentValue;
+}
+
+/// Configures integrator for production
+/// disables further move step size adjustment
+///
+template <class T,
+        class RandomNumberGenerator>
+void
+IntegratorMSMC<T, RandomNumberGenerator>::
+setEquilibrationFinished() {
+    for(unsigned int i = 0; i < mcMoves.size(); ++i)
+    {
+        mcMoves[i]->tunable = false;
+    }
 }
 
 }

--- a/cpp/libzeno/include/Virials/MeterOverlap.h
+++ b/cpp/libzeno/include/Virials/MeterOverlap.h
@@ -266,7 +266,7 @@ MeterOverlap<T>::
 collectData(double primaryValue, bool accepted) {
     double pi = std::abs(primaryValue);
     if (pi == 0 || pi == std::numeric_limits<double>::infinity() || std::isnan(pi)) {
-        std::cerr << "pi is" << pi << std::endl;
+        std::cerr << "pi is " << pi << std::endl;
         exit(1);
     }
     if(accepted || perturbValue == -1){

--- a/cpp/libzeno/include/Virials/ResultsVirial.h
+++ b/cpp/libzeno/include/Virials/ResultsVirial.h
@@ -44,10 +44,12 @@ public:
     }
     double getRefFrac() const;
     Uncertain<double> getRefAverageReduced() const;
-    Uncertain<double> getRefOverlapAverageReduced() const;
     Uncertain<double> getTargetAverageReduced() const;
-    Uncertain<double> getTargetOverlapAverageReduced() const;
+    Uncertain<double> getOverlapRatioAverageReduced() const;
     double getRefIntegral() const;
+    void putOverlapRatio(int threadNum,
+                         double overlapRatio,
+                         double uncertainty);
     void putVirialCoefficient(int threadNum,
                               double coefficient,
                               double uncertainty);
@@ -59,13 +61,11 @@ public:
 
 private:
     Uncertain<double> * refAverage;
-    Uncertain<double> * refOverlapAverage;
     Uncertain<double> * targetAverage;
-    Uncertain<double> * targetOverlapAverage;
+    Uncertain<double> * overlapRatioAverage;
     Uncertain<double> refAverageReduced;
-    Uncertain<double> refOverlapAverageReduced;
     Uncertain<double> targetAverageReduced;
-    Uncertain<double> targetOverlapAverageReduced;
+    Uncertain<double> overlapRatioAverageReduced;
     int numThreads;
     bool reduced;
     long long * refNumSteps;

--- a/cpp/libzeno/include/Virials/VirialAlpha.h
+++ b/cpp/libzeno/include/Virials/VirialAlpha.h
@@ -203,11 +203,11 @@ runSteps(int numSteps) {
         if (jBestAlpha<numAlpha*0.1 || jBestAlpha>(numAlpha-1)*0.9) alphaSpan *= 2;
         else if (alphaCor < 0.3 && alphaSpan > 0.5 && jBestAlpha>numAlpha*0.2 && jBestAlpha<(numAlpha-1)*0.8) alphaSpan *= 0.25;
         else if (alphaCor < 0.6 && alphaSpan > 0.5 && jBestAlpha>numAlpha*0.2 && jBestAlpha<(numAlpha-1)*0.8) alphaSpan *= 0.6;
-        else if (alphaCor > 0.2) nextCheckFac *= 2;
-        else if (alphaCor < 0.1 && newAlphaErr/newAlpha < 0.02) allDone = true;
+        else if (alphaCor > 0.2 || newAlphaErr/newAlpha > 0.1) nextCheckFac = 2;
+        else if (alphaCor < 0.1) allDone = true;
+        if (alphaSpan < 0.5) alphaSpan = 0.5;
         setAlpha(newAlpha, alphaSpan);
-        nextCheck *= nextCheckFac;
-        nextCheck = stepCount + nextCheck;
+        nextCheck = stepCount * (1 + nextCheckFac);
         if (nextCheck > targetMeter.getBlockSize() * 200) targetMeter.setBlockSize(nextCheck / 200);
     }
 }

--- a/cpp/libzeno/include/Virials/VirialAlpha.h
+++ b/cpp/libzeno/include/Virials/VirialAlpha.h
@@ -207,6 +207,8 @@ runSteps(int numSteps) {
         setAlpha(newAlpha, alphaSpan);
         nextCheck *= nextCheckFac;
         nextCheck = stepCount + nextCheck;
+        if (nextCheck > targetMeter.getBlockSize() * 200) targetMeter.setBlockSize(nextCheck / 200);
+        if (nextCheck > refMeter.getBlockSize() * 200) targetMeter.setBlockSize(nextCheck / 200);
     }
 }
 

--- a/cpp/libzeno/include/Virials/VirialAlpha.h
+++ b/cpp/libzeno/include/Virials/VirialAlpha.h
@@ -75,6 +75,7 @@ VirialAlpha(IntegratorMSMC<T, RandomNumberGenerator> & rIntegrator,
     int numAlpha = refMeter.getNumAlpha();
     const double *alpha = refMeter.getAlpha();
     alphaSpan = std::log(alpha[numAlpha-1]/alpha[0]);
+    refMeter.setBlockSize(1);
     refIntegrator.setMeter(&refMeter);
     targetIntegrator.setMeter(&targetMeter);
 }
@@ -208,7 +209,6 @@ runSteps(int numSteps) {
         nextCheck *= nextCheckFac;
         nextCheck = stepCount + nextCheck;
         if (nextCheck > targetMeter.getBlockSize() * 200) targetMeter.setBlockSize(nextCheck / 200);
-        if (nextCheck > refMeter.getBlockSize() * 200) targetMeter.setBlockSize(nextCheck / 200);
     }
 }
 

--- a/cpp/libzeno/include/Virials/VirialAlpha.h
+++ b/cpp/libzeno/include/Virials/VirialAlpha.h
@@ -68,8 +68,8 @@ VirialAlpha(IntegratorMSMC<T, RandomNumberGenerator> & rIntegrator,
             ClusterSum<T> & targetClusterRef,
             ClusterSum<T> & targetClusterTarget) :
             stepCount(0), nextCheck(1000), refIntegrator(rIntegrator), targetIntegrator(tIntegrator),
-            refMeter(MeterOverlap<T>(refClusterTarget, 1, 5, 10)),
-            targetMeter(MeterOverlap<T>(targetClusterRef, 1, -5, 10)),
+            refMeter(MeterOverlap<T>(refClusterTarget, 1, 5, 11)),
+            targetMeter(MeterOverlap<T>(targetClusterRef, 1, -5, 11)),
             newAlpha(0), newAlphaErr(0), alphaCor(0), alphaSpan(0), allDone(false),
             verbose(false) {
     int numAlpha = refMeter.getNumAlpha();
@@ -200,12 +200,12 @@ runSteps(int numSteps) {
         if (verbose) printf("alpha  avg: %22.15e   err: %12.5e   cor: % 6.4f\n", newAlpha, newAlphaErr, alphaCor);
         int numAlpha = refMeter.getNumAlpha();
         double nextCheckFac = 1.4;
-        if (jBestAlpha<numAlpha*0.1 || jBestAlpha>(numAlpha-1)*0.9) alphaSpan *= 2;
-        else if (alphaCor < 0.3 && alphaSpan > 0.5 && jBestAlpha>numAlpha*0.2 && jBestAlpha<(numAlpha-1)*0.8) alphaSpan *= 0.25;
-        else if (alphaCor < 0.6 && alphaSpan > 0.5 && jBestAlpha>numAlpha*0.2 && jBestAlpha<(numAlpha-1)*0.8) alphaSpan *= 0.6;
+        if (jBestAlpha==0 || jBestAlpha>(numAlpha-1)*0.999999) alphaSpan *= 2;
+        else if (alphaCor < 0.3 && alphaSpan > 1 && jBestAlpha>numAlpha*0.2 && jBestAlpha<(numAlpha-1)*0.8) alphaSpan *= 0.25;
+        else if (alphaCor < 0.6 && alphaSpan > 1 && jBestAlpha>numAlpha*0.2 && jBestAlpha<(numAlpha-1)*0.8) alphaSpan *= 0.6;
         else if (alphaCor > 0.2 || newAlphaErr/newAlpha > 0.1) nextCheckFac = 2;
         else if (alphaCor < 0.1) allDone = true;
-        if (alphaSpan < 0.5) alphaSpan = 0.5;
+        if (alphaSpan < 1) alphaSpan = 1;
         setAlpha(newAlpha, alphaSpan);
         nextCheck = stepCount * (1 + nextCheckFac);
         if (nextCheck > targetMeter.getBlockSize() * 200) targetMeter.setBlockSize(nextCheck / 200);

--- a/cpp/libzeno/include/Virials/VirialProduction.h
+++ b/cpp/libzeno/include/Virials/VirialProduction.h
@@ -90,6 +90,8 @@ VirialProduction(IntegratorMSMC<T, RandomNumberGenerator> & rIntegrator,
     fullBCStats = (double**)malloc2D(numTargets-1, numTargets-1, sizeof(double));
     refIntegrator.setMeter(&refMeter);
     targetIntegrator.setMeter(&targetMeter);
+    refIntegrator.setEquilibrationFinished();
+    targetIntegrator.setEquilibrationFinished();
 }
 
 template <class T,

--- a/cpp/libzeno/src/Virials/ParametersVirial.cc
+++ b/cpp/libzeno/src/Virials/ParametersVirial.cc
@@ -144,8 +144,8 @@ ParametersVirial::serializeMpiBroadcast(int root) const {
 
   longLongsArray[0] = (long long)getNumThreads();
   longLongsArray[1] = (long long)getSeed();
-  longLongsArray[2] = (long long)getStepsWasSet();
-  longLongsArray[3] = getSteps();
+  longLongsArray[2] = getSteps();
+  longLongsArray[3] = (long long)getStepsWasSet();
   longLongsArray[4] = getOrder();
 
   MPI_Bcast(longLongsArray, numLongLongsToSend, MPI_LONG_LONG,

--- a/cpp/libzeno/src/Virials/ParametersVirial.cc
+++ b/cpp/libzeno/src/Virials/ParametersVirial.cc
@@ -173,6 +173,6 @@ ParametersVirial::mpiBroadcastDeserialize(int root) {
     setSteps(longLongsArray[2]);
   }
 
-  setOrder((bool)longLongsArray[4]);
+  setOrder(longLongsArray[4]);
 #endif
 }

--- a/cpp/libzeno/src/Zeno.cc
+++ b/cpp/libzeno/src/Zeno.cc
@@ -995,6 +995,8 @@ Zeno::doVirialSamplingThread(ParametersVirial const * parameters,
     VirialProduction<double, RandomNumberGenerator> virialProduction(refIntegrator,targetIntegrator,
             clusterSumRef, clusterSumTarget, clusterSumRefT, clusterSumTargetT, alphaStats[0],
             resultsVirial->getRefIntegral());
+    virialProduction.getRefMeter()->setBlockSize(1);
+    virialProduction.getTargetMeter()->setBlockSize(std::max(stepsInThread / 1000, 1LL));
     virialProduction.runSteps(stepsInThread);
     //virialProduction.printResults(NULL);
 

--- a/cpp/libzeno/src/Zeno.cc
+++ b/cpp/libzeno/src/Zeno.cc
@@ -1001,5 +1001,6 @@ Zeno::doVirialSamplingThread(ParametersVirial const * parameters,
     //virialProduction.printResults(NULL);
 
     resultsVirial->putData(threadNum, virialProduction.getRefMeter(), virialProduction.getTargetMeter());
+    resultsVirial->putOverlapRatio(threadNum, virialProduction.getAlphaStats()[0], std::pow(virialProduction.getAlphaStats()[1],2));
     resultsVirial->putVirialCoefficient(threadNum, virialProduction.getFullStats()[0][0], std::pow(virialProduction.getFullStats()[0][1],2));
 }

--- a/cpp/libzeno/src/Zeno.cc
+++ b/cpp/libzeno/src/Zeno.cc
@@ -903,7 +903,7 @@ Zeno::doVirialSampling(ParametersVirial const & parameters,
 
     for (int threadNum = 0; threadNum < numThreads; threadNum++) {
 
-        long long stepsInThread = parameters.getSteps() / numThreads;
+        long long stepsInThread = stepsInProcess / numThreads;
 
         if (threadNum < stepsInProcess % numThreads) {
             stepsInThread ++;

--- a/cpp/libzeno/src/Zeno.cc
+++ b/cpp/libzeno/src/Zeno.cc
@@ -866,7 +866,9 @@ Zeno::getVirialResults
  ResultsVirial * * resultsVirial) {
 
   double refDiameter = 2 * boundingSphere.getRadius();
-  double refIntegral = std::pow(4.0*M_PI*refDiameter*refDiameter*refDiameter/3.0,parametersVirial.getOrder()-1)/2;
+  int nFactorial = 1;
+  for (int i=2; i<=parametersVirial.getOrder(); i++) nFactorial *= i;
+  double refIntegral = nFactorial*std::pow(4.0*M_PI*refDiameter*refDiameter*refDiameter/3.0,parametersVirial.getOrder()-1)/2;
   *resultsVirial = new ResultsVirial(parametersVirial.getNumThreads(),
                                      refIntegral);
 

--- a/cpp/zeno-cli/src/Main.cc
+++ b/cpp/zeno-cli/src/Main.cc
@@ -848,7 +848,7 @@ runZeno(ParametersLocal const & parametersLocal,
     if (parametersLocal.getPrintBenchmarks() && 
 	parametersLocal.getMpiRank() == 0) {
 
-      printRAM("interior samples",
+      printRAM("virial steps",
 	       csvItems);
     }
   }


### PR DESCRIPTION
Since the original pull request, we've identified several needed fixes to make ZENO compute virial coefficients properly, including

1. Not crashing when MPI is used
2. Communicating virial results across MPI processes
3. Having MPI processes run for the correct # of steps
4. Including n! in the final virial coefficient value
5. Adjust the MC step size
6. Set appropriate block sizes for computing uncertainties

Also, the algorithm to converge to an appropriate value of alpha (the overlap parameter) has been tweaked to not get stuck, and to converge more efficiently.