### PR TITLE
Update WalkerExterior.h

### DIFF
--- a/cpp/libzeno/include/Walker/WalkerExterior.h
+++ b/cpp/libzeno/include/Walker/WalkerExterior.h
@@ -153,6 +153,8 @@ WalkerExterior<T,
       
       return;
     }
+	  
+    minDistance += shellThickness;
 
     (*numSteps)++;
 


### PR DESCRIPTION
Now adds `shellThickness` to `minDistance` (radius) before picking a uniform random point on the surface of the sphere.

Please add this pull request to a new branch so that proper testing can be conducted before merging into the master branch.